### PR TITLE
pc/kp - add .env.* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # dotenv environment variables file
 .env
-.env.test
+.env.*
 
 # Logs
 logs


### PR DESCRIPTION
In this PR, we  add `.env.*` to `.gitignore` so that we don't accidentally commit secrets into the GitHub repo.