### PR TITLE
pc/kp - add admin link in production app

### DIFF
--- a/templates/user_select_commons.ejs
+++ b/templates/user_select_commons.ejs
@@ -33,6 +33,23 @@
                             </div>
                         </div>
                     </div>
+
+                    <% if (data && data.user && data.user.type && data.user.type==='admin') { %>
+                        <div class="row">
+                            <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12">
+                                <div class="card special-card">
+                                    <div class="page-caption">
+                                        <!-- <h1 class="ml9"> -->
+                                            <span class="text-wrapper">
+                                                <span class="letters"><a href="/admin">admin page</a></span>
+                                            </span>
+                                        <!-- </h1> -->
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    <% } %>
+
                     <div class = "row mt-5">
                         <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-6">
                             <div class="card special-card">

--- a/views/user_choose_commons.js
+++ b/views/user_choose_commons.js
@@ -8,7 +8,8 @@ module.exports = async (req, res)=>{
     {data: 
         {
             commons: commons,
-            commons_user: commons_user
+            commons_user: commons_user,
+            user: user_obj
         }
     }
 )};


### PR DESCRIPTION
In this PR, we add a link for admins on the `/choosecommons` page.

For regular users, the heading looks like this (this is unchanged):

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/1119017/115932288-80765400-a441-11eb-9116-1ea15209bd22.png">

For admin users, the page now looks like this:

<img width="1026" alt="image" src="https://user-images.githubusercontent.com/1119017/115932386-b0bdf280-a441-11eb-9b2f-a48458d660b1.png">

The link takes the user to the admin page.
