### PR TITLE
Pc add script for cron (Hotfix)

### DIFF
--- a/bin/newUserReport.sh
+++ b/bin/newUserReport.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Starting job $0 at `date`"
+cd  /home/web-chem123/HappyCows
+/usr/bin/node bin/newUserReport.js
+echo "Job $0 Complete at `date`"
+

--- a/templates/admin_commons.ejs
+++ b/templates/admin_commons.ejs
@@ -59,51 +59,6 @@
                     </div>
                 </div>
                 
-                
-                <div class="card">
-                    <h5 class="card-header">Players </h5>
-                    <div class="card-body">
-                        <table class="table">
-                            <thead>
-                                <tr>
-                                    <th scope="col">#</th>
-                                    <th scope="col">#</th>
-                                    <th scope="col">First</th>
-                                    <th scope="col">Last</th>
-                                    <th scope="col">Email</th>
-                                    <th scope="col">Type</th>
-                                    <th scope="col">Money</th>
-                                    <th scope="col">Cows</th>
-                                    <th scope="col">Delete</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <% data.users.forEach(result=>{ %>
-                                <tr>
-                                    <th scope="row"><%= result["id"] %></th>
-                                    <% Object.keys(result).map((key)=>{ %>
-                                        <td><%=result[key]%></td>
-                                    <% }); %>
-                                    <td>
-                                        <form action="remove_player" method="post">
-                                            <input type="hidden" class="form-control" name="cid" id="cid"
-                                                            value="<%= data.commonId %>">
-                                            <button type="submit" class="btn btn-danger btn-sm">
-                                                <ion-icon name="close-outline"></ion-icon>
-                                            </button>
-                                        </form>                    
-                                    </td>
-                                </tr>
-                                <% }); %>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-
-            </div>
-        </div>
-
-
         <div class="row mt-3">
             <div class="col">
                 <div class="card">

--- a/views/admin_common_get.js
+++ b/views/admin_common_get.js
@@ -5,7 +5,6 @@ const {get_reports} = require("../apis/admin/commons");
 const moment = require('moment');
 
 module.exports = async (req, res) => {
-   // const users = await get_users_in_common(req, req.params.commonId);
     const cowPrice = await get_cow_price(req.params.commonId);
     const cowMax = await get_max_cow(req.params.commonId);
     const degradeRate = await get_degrade_rate(req.params.commonId);
@@ -19,7 +18,6 @@ module.exports = async (req, res) => {
     res.render('admin_commons',
         {data :
             {
-              //  users: users,
                 commonId: req.params.commonId,
                 cowPrice: cowPrice,
                 cowMax: cowMax,

--- a/views/admin_common_get.js
+++ b/views/admin_common_get.js
@@ -5,7 +5,7 @@ const {get_reports} = require("../apis/admin/commons");
 const moment = require('moment');
 
 module.exports = async (req, res) => {
-    const users = await get_users_in_common(req, req.params.commonId);
+   // const users = await get_users_in_common(req, req.params.commonId);
     const cowPrice = await get_cow_price(req.params.commonId);
     const cowMax = await get_max_cow(req.params.commonId);
     const degradeRate = await get_degrade_rate(req.params.commonId);
@@ -19,7 +19,7 @@ module.exports = async (req, res) => {
     res.render('admin_commons',
         {data :
             {
-                users: users,
+              //  users: users,
                 commonId: req.params.commonId,
                 cowPrice: cowPrice,
                 cowMax: cowMax,

--- a/views/admin_report.js
+++ b/views/admin_report.js
@@ -11,7 +11,8 @@ module.exports = async (req, res) => {
                 reports: reports,
                 reportItems: reportItems
             },
-        moment: moment
+        moment: moment,
+        dateFormat: "ddd MM/DD/YYYY hh:mm:ssA"
         }
     )
 };


### PR DESCRIPTION
In this PR, we add a script for a cron job to produce reports for each commons.

This script is run with a crontab entry like this one, each night at midnight:

```
0 0 * * * /home/web-chem123/HappyCows/bin/newUserReport.sh >> /home/web-chem123/logs/cron.log  2>&1
```

We also eliminated the user report on the admin commons page: it was only providing data for the first 15 users, and it was causing the page load time to be longer than the web server timeout.    The information that was on the eliminated user report is now available via the report produced by the cron job.

We also fixed the missing `dateFormat` variable in one of the files.