### PR TITLE
pc - update SQL in newUserReport.js to be more efficient

### DIFF
--- a/bin/newUserReport.js
+++ b/bin/newUserReport.js
@@ -21,8 +21,8 @@ async function get_users_in_commons_and_make_report(commonId, reportId) {
 	console.log(`starting report for commons ${commonId}...`)
 	return db.sequelize.query(
 		'SELECT u.id, u.firstName, u.lastName, u.email, u.type, ' +
-		`(${get_wealth} u.id AND CommonId = ?) AS wealth, ` +
-		`(${get_cows} u.id AND CommonId = ?) AS cows ` +
+		`(SELECT SUM(wealth) FROM UserWealths WHERE UserId = u.id AND CommonId = ?) AS wealth, ` +
+		`(SELECT COUNT(health) FROM Cows WHERE UserId = u.id AND CommonId = ?) AS cows ` +
 		'FROM UserCommons AS uc JOIN Users AS u ON u.id = uc.UserId  WHERE uc.CommonId = ? ',
 		{
 			replacements: [


### PR DESCRIPTION
In this PR, we change the SQL in the `bin/newUserReport.js` file, the job that runs every night at midnight to produce the reports for admins, to make it more efficient.

It previously took 17 minutes 46 seconds.  Now it takes 12 seconds.

The previous SQL looked like this:

```js
'SELECT u.id, u.firstName, u.lastName, u.email, u.type, ' +
 `(${get_wealth} u.id AND CommonId = ?) AS wealth, ` +
 `(${get_cows} u.id AND CommonId = ?) AS cows ` +
 'FROM UserCommons AS uc JOIN Users AS u ON u.id = uc.UserId WHERE    uc.CommonId = ? ' 
```

Substituting in the values of `get_wealth` and `get_cows`:

```js
module.exports = {
 get_wealth: "SELECT SUM(wealth) FROM UserWealths WHERE UserId = ",
 get_cows: "SELECT COUNT(wealth) FROM Cows WHERE UserId = ",
 get_health: "SELECT AVG(health) FROM Cows WHERE CommonId = ",
 get_players: "SELECT COUNT(*) FROM UserCommons WHERE CommonId = "};
```

Resulted in:

```sql
SELECT u.id, u.firstName, u.lastName, u.email, u.type, 
 (SELECT SUM(wealth) FROM UserWealths WHERE UserId = u.id AND CommonId = ?) AS wealth, 
 (SELECT COUNT(wealth) FROM Cows WHERE UserId =  u.id AND CommonId = ?) AS cows 
 FROM UserCommons AS uc JOIN Users AS u ON u.id = uc.UserId WHERE    uc.CommonId = ? 
```

The part that made little sense was this:

``` 
 (SELECT COUNT(wealth) FROM Cows WHERE UserId =  u.id AND CommonId = ?) AS cows 
```

This `COUNT(wealth) FROM Cows` required a cartesian product between the `Cows` table and the `UserWealths` table.  Given that the `UserWealths` table has on the order of 700K rows in it, this took a while.  But it was entirely unnecessary.  We are just counting cows.   So, substituting a field from the Cows table, we get:  `COUNT(health) FROM Cows`.   Same result, but two orders of magnitude faster (10s of seconds instead of 1000s  of seconds).